### PR TITLE
Add RFC 1123 validation to component name fields

### DIFF
--- a/skeleton/backstage/template.yaml
+++ b/skeleton/backstage/template.yaml
@@ -25,6 +25,7 @@ spec:
             rows: 5
           ui:field: EntityNamePicker
           maxLength: 63
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
         owner:
           title: Owner
           type: string

--- a/templates/devfile-sample-code-with-quarkus-dance/template.yaml
+++ b/templates/devfile-sample-code-with-quarkus-dance/template.yaml
@@ -25,6 +25,7 @@ spec:
             rows: 5
           ui:field: EntityNamePicker
           maxLength: 63
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
         owner:
           title: Owner
           type: string
@@ -34,6 +35,9 @@ spec:
           ui:options:
             catalogFilter:
               kind: [Group, User]
+      errorMessage:
+        properties:
+          name: 'Name must be lowercase alphanumeric characters or hyphens, starting and ending with alphanumeric characters (e.g. "my-app", "app123")'
     - title: Application Repository Information
       required:
         - hostType

--- a/templates/devfile-sample-dotnet60-dance/template.yaml
+++ b/templates/devfile-sample-dotnet60-dance/template.yaml
@@ -25,6 +25,7 @@ spec:
             rows: 5
           ui:field: EntityNamePicker
           maxLength: 63
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
         owner:
           title: Owner
           type: string
@@ -34,6 +35,9 @@ spec:
           ui:options:
             catalogFilter:
               kind: [Group, User]
+      errorMessage:
+        properties:
+          name: 'Name must be lowercase alphanumeric characters or hyphens, starting and ending with alphanumeric characters (e.g. "my-app", "app123")'
     - title: Application Repository Information
       required:
         - hostType

--- a/templates/devfile-sample-go-dance/template.yaml
+++ b/templates/devfile-sample-go-dance/template.yaml
@@ -25,6 +25,7 @@ spec:
             rows: 5
           ui:field: EntityNamePicker
           maxLength: 63
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
         owner:
           title: Owner
           type: string
@@ -34,6 +35,9 @@ spec:
           ui:options:
             catalogFilter:
               kind: [Group, User]
+      errorMessage:
+        properties:
+          name: 'Name must be lowercase alphanumeric characters or hyphens, starting and ending with alphanumeric characters (e.g. "my-app", "app123")'
     - title: Application Repository Information
       required:
         - hostType

--- a/templates/devfile-sample-java-springboot-dance/template.yaml
+++ b/templates/devfile-sample-java-springboot-dance/template.yaml
@@ -25,6 +25,7 @@ spec:
             rows: 5
           ui:field: EntityNamePicker
           maxLength: 63
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
         owner:
           title: Owner
           type: string
@@ -34,6 +35,9 @@ spec:
           ui:options:
             catalogFilter:
               kind: [Group, User]
+      errorMessage:
+        properties:
+          name: 'Name must be lowercase alphanumeric characters or hyphens, starting and ending with alphanumeric characters (e.g. "my-app", "app123")'
     - title: Application Repository Information
       required:
         - hostType

--- a/templates/devfile-sample-nodejs-dance/template.yaml
+++ b/templates/devfile-sample-nodejs-dance/template.yaml
@@ -25,6 +25,7 @@ spec:
             rows: 5
           ui:field: EntityNamePicker
           maxLength: 63
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
         owner:
           title: Owner
           type: string
@@ -34,6 +35,9 @@ spec:
           ui:options:
             catalogFilter:
               kind: [Group, User]
+      errorMessage:
+        properties:
+          name: 'Name must be lowercase alphanumeric characters or hyphens, starting and ending with alphanumeric characters (e.g. "my-app", "app123")'
     - title: Application Repository Information
       required:
         - hostType

--- a/templates/devfile-sample-python-dance/template.yaml
+++ b/templates/devfile-sample-python-dance/template.yaml
@@ -25,6 +25,7 @@ spec:
             rows: 5
           ui:field: EntityNamePicker
           maxLength: 63
+          pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
         owner:
           title: Owner
           type: string
@@ -34,6 +35,9 @@ spec:
           ui:options:
             catalogFilter:
               kind: [Group, User]
+      errorMessage:
+        properties:
+          name: 'Name must be lowercase alphanumeric characters or hyphens, starting and ending with alphanumeric characters (e.g. "my-app", "app123")'
     - title: Application Repository Information
       required:
         - hostType


### PR DESCRIPTION
- Add pattern validation to ensure component names are lowercase alphanumeric with hyphens
- Prevents ArgoCD creation failures from invalid metadata.name values
- Includes custom error messages with examples for better user experience
- Fixes validation for all template files: Python, Go, Quarkus, Java, .NET, Node.js

Pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
Resolves component creation failures with uppercase/special characters